### PR TITLE
catalog-to-ds.xsl: append to Import-Package instead of overwrite

### DIFF
--- a/modules-build-helper/src/main/resources/org/daisy/pipeline/modules/build/catalog-to-ds.xsl
+++ b/modules-build-helper/src/main/resources/org/daisy/pipeline/modules/build/catalog-to-ds.xsl
@@ -15,7 +15,7 @@
         <xsl:result-document href="{$outputDir}/bnd.bnd" method="text" xml:space="preserve">
 <xsl:if test="//cat:nextCatalog">Require-Bundle: <xsl:value-of select="string-join(//cat:nextCatalog/translate(@catalog,':','.'),',')"/></xsl:if>
 <xsl:if test="//cat:uri[@px:script]">Service-Component: <xsl:value-of select="string-join(//cat:uri[@px:script]/concat('OSGI-INF/',substring-after(document(@uri,..)/*/@type,':'),'.xml'),',')"/>
-Import-Package: org.daisy.pipeline.script</xsl:if>
+Import-Package: org.daisy.pipeline.script, *</xsl:if>
         </xsl:result-document>
 
         <xsl:apply-templates mode="ds"/>

--- a/modules-parent/pom.xml
+++ b/modules-parent/pom.xml
@@ -261,7 +261,7 @@
               <dependency>
                 <groupId>org.daisy.pipeline.build</groupId>
                 <artifactId>modules-build-helper</artifactId>
-                <version>1.1</version>
+                <version>1.2-SNAPSHOT</version>
               </dependency>
             </dependencies>
           </plugin>


### PR DESCRIPTION
Overwriting is a problem if a script module also contains Java