### PR TITLE
Make pax-exam-helper smarter by automatically resolving transitive dependencies

### DIFF
--- a/pax-exam-helper/pom.xml
+++ b/pax-exam-helper/pom.xml
@@ -193,6 +193,10 @@
               <postBuildHookScript>verify</postBuildHookScript>
               <properties>
                 <pax-exam-helper.version>${project.version}</pax-exam-helper.version>
+                <xspec-runner.version>1.0.0</xspec-runner.version>
+                <xprocspec.version>1.1.0</xprocspec.version>
+                <xprocspec-runner.version>1.0.0</xprocspec-runner.version>
+                <xproc-engine-daisy-pipeline.version>1.10</xproc-engine-daisy-pipeline.version>
               </properties>
               <goals>
                 <goal>clean</goal>

--- a/pax-exam-helper/pom.xml
+++ b/pax-exam-helper/pom.xml
@@ -22,9 +22,31 @@
     <pax-exam.version>3.3.0</pax-exam.version>
     <junit.version>4.11</junit.version>
     <logback.version>0.9.20</logback.version>
+    <aether.version>1.13.1</aether.version>
+    <maven.version>3.0.4</maven.version>
   </properties>
   
   <dependencies>
+    <dependency>
+      <groupId>org.sonatype.aether</groupId>
+      <artifactId>aether-api</artifactId>
+      <version>${aether.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.aether</groupId>
+      <artifactId>aether-util</artifactId>
+      <version>${aether.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-aether-provider</artifactId>
+      <version>${maven.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.5.11</version>
+    </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam</artifactId>
@@ -64,12 +86,6 @@
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-link-mvn</artifactId>
       <version>${pax-exam.version}</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.5.11</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/pax-exam-helper/pom.xml
+++ b/pax-exam-helper/pom.xml
@@ -12,7 +12,7 @@
   
   <groupId>org.daisy.pipeline</groupId>
   <artifactId>pax-exam-helper</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0</version>
   <packaging>bundle</packaging>
   
   <name>DAISY Pipeline 2 :: Pax Exam Helper</name>
@@ -208,4 +208,8 @@
       </plugin>
     </plugins>
   </build>
+
+  <scm>
+    <tag>pax-exam-helper-2.0.0</tag>
+  </scm>
 </project>

--- a/pax-exam-helper/pom.xml
+++ b/pax-exam-helper/pom.xml
@@ -12,7 +12,7 @@
   
   <groupId>org.daisy.pipeline</groupId>
   <artifactId>pax-exam-helper</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1-SNAPSHOT</version>
   <packaging>bundle</packaging>
   
   <name>DAISY Pipeline 2 :: Pax Exam Helper</name>
@@ -208,8 +208,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <scm>
-    <tag>pax-exam-helper-2.0.0</tag>
-  </scm>
 </project>

--- a/pax-exam-helper/pom.xml
+++ b/pax-exam-helper/pom.xml
@@ -21,9 +21,11 @@
     <felix.version>4.4.1</felix.version>
     <pax-exam.version>3.3.0</pax-exam.version>
     <junit.version>4.11</junit.version>
-    <logback.version>0.9.20</logback.version>
+    <slf4j.version>1.6.3</slf4j.version>
+    <logback.version>0.9.30</logback.version>
     <aether.version>1.13.1</aether.version>
     <maven.version>3.0.4</maven.version>
+    <wagon.version>2.2</wagon.version>
   </properties>
   
   <dependencies>
@@ -38,14 +40,35 @@
       <version>${aether.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.sonatype.aether</groupId>
+      <artifactId>aether-connector-wagon</artifactId>
+      <version>${aether.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-aether-provider</artifactId>
       <version>${maven.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.wagon</groupId>
+      <artifactId>wagon-provider-api</artifactId>
+      <version>${wagon.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.wagon</groupId>
+      <artifactId>wagon-http</artifactId>
+      <version>${wagon.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.5.11</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.exam</groupId>

--- a/pax-exam-helper/pom.xml
+++ b/pax-exam-helper/pom.xml
@@ -12,7 +12,7 @@
   
   <groupId>org.daisy.pipeline</groupId>
   <artifactId>pax-exam-helper</artifactId>
-  <version>1.9.2-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <packaging>bundle</packaging>
   
   <name>DAISY Pipeline 2 :: Pax Exam Helper</name>

--- a/pax-exam-helper/src/it/it-pax-exam-xprocspec/pom.xml
+++ b/pax-exam-helper/src/it/it-pax-exam-xprocspec/pom.xml
@@ -8,12 +8,6 @@
   <artifactId>it-pax-exam-xprocspec</artifactId>
   <version>0.0-SNAPSHOT</version>
   
-  <properties>
-    <xprocspec.version>1.1.0</xprocspec.version>
-    <xprocspec-runner.version>1.0.0</xprocspec-runner.version>
-    <xproc-engine-daisy-pipeline.version>1.9</xproc-engine-daisy-pipeline.version>
-  </properties>
-  
   <dependencies>
     <dependency>
       <groupId>org.daisy.maven</groupId>

--- a/pax-exam-helper/src/it/it-pax-exam-xprocspec/src/test/java/XProcSpecTest.java
+++ b/pax-exam-helper/src/it/it-pax-exam-xprocspec/src/test/java/XProcSpecTest.java
@@ -5,9 +5,11 @@ import javax.inject.Inject;
 import org.daisy.maven.xproc.xprocspec.XProcSpecRunner;
 
 import static org.daisy.pipeline.pax.exam.Options.felixDeclarativeServices;
-import static org.daisy.pipeline.pax.exam.Options.logbackBundles;
+import static org.daisy.pipeline.pax.exam.Options.logbackClassic;
 import static org.daisy.pipeline.pax.exam.Options.logbackConfigFile;
-import static org.daisy.pipeline.pax.exam.Options.xprocspecBundles;
+import static org.daisy.pipeline.pax.exam.Options.mavenBundle;
+import static org.daisy.pipeline.pax.exam.Options.mavenBundlesWithDependencies;
+import static org.daisy.pipeline.pax.exam.Options.xprocspec;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,9 +36,12 @@ public class XProcSpecTest {
 		return options(
 			systemProperty("com.xmlcalabash.config.user").value(""),
 			logbackConfigFile(),
-			logbackBundles(),
 			felixDeclarativeServices(),
-			xprocspecBundles(),
+			mavenBundlesWithDependencies(
+				logbackClassic(),
+				// xprocspec
+				xprocspec(),
+				mavenBundle("org.daisy.maven:xproc-engine-daisy-pipeline:?")),
 			junitBundles()
 		);
 	}

--- a/pax-exam-helper/src/it/it-pax-exam-xspec/pom.xml
+++ b/pax-exam-helper/src/it/it-pax-exam-xspec/pom.xml
@@ -8,10 +8,6 @@
   <artifactId>it-pax-exam-xspec</artifactId>
   <version>1.0-SNAPSHOT</version>
   
-  <properties>
-    <xspec-runner.version>1.0.0</xspec-runner.version>
-  </properties>
-  
   <dependencies>
     <dependency>
       <groupId>org.daisy.pipeline</groupId>

--- a/pax-exam-helper/src/it/it-pax-exam-xspec/src/test/java/XSpecTest.java
+++ b/pax-exam-helper/src/it/it-pax-exam-xspec/src/test/java/XSpecTest.java
@@ -6,9 +6,11 @@ import org.daisy.maven.xspec.TestResults;
 import org.daisy.maven.xspec.XSpecRunner;
 
 import static org.daisy.pipeline.pax.exam.Options.felixDeclarativeServices;
-import static org.daisy.pipeline.pax.exam.Options.logbackBundles;
+import static org.daisy.pipeline.pax.exam.Options.logbackClassic;
 import static org.daisy.pipeline.pax.exam.Options.logbackConfigFile;
-import static org.daisy.pipeline.pax.exam.Options.xspecBundles;
+import static org.daisy.pipeline.pax.exam.Options.mavenBundle;
+import static org.daisy.pipeline.pax.exam.Options.mavenBundlesWithDependencies;
+import static org.daisy.pipeline.pax.exam.Options.xspec;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,7 +25,6 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.ops4j.pax.exam.util.PathUtils;
 
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
 @RunWith(PaxExam.class)
@@ -34,9 +35,13 @@ public class XSpecTest {
 	public Option[] config() {
 		return options(
 			logbackConfigFile(),
-			logbackBundles(),
 			felixDeclarativeServices(),
-			xspecBundles(),
+			mavenBundlesWithDependencies(
+				logbackClassic(),
+				// xspec
+				xspec(),
+				mavenBundle("org.apache.servicemix.bundles:org.apache.servicemix.bundles.xmlresolver:?"),
+				mavenBundle("org.daisy.pipeline:saxon-adapter:?")),
 			junitBundles()
 		);
 	}

--- a/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
+++ b/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
@@ -180,7 +180,11 @@ public abstract class Options {
 				if (classifier != null && !"".equals(classifier))
 					bundle.classifier(classifier);
 				if (versionAsInProject)
-					version = MavenUtils.asInProject().getVersion(groupId, artifactId);
+					try {
+						version = MavenUtils.asInProject().getVersion(groupId, artifactId); }
+					catch (Throwable e) {
+						logger.error("Could not find version of " + groupId + ":" + artifactId + " in Maven project");
+						throw new RuntimeException("Could not find version of " + groupId + ":" + artifactId + " in Maven project"); }
 				bundle.version(version);
 				// special handling of xprocspec
 				if (groupId.equals("org.daisy.xprocspec") && artifactId.equals("xprocspec"))

--- a/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
+++ b/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
@@ -327,7 +327,7 @@ public abstract class Options {
 					.setLocalRepositoryManager(
 						system.newLocalRepositoryManager(
 							new LocalRepository(LOCAL_REPOSITORY.getAbsolutePath())))
-					.setOffline(true);
+					.setOffline(false);
 				Set<Artifact> deps = new HashSet<Artifact>();
 				try {
 					addDependencies(deps, system.resolveDependencies(session, new DependencyRequest().setCollectRequest(request)).getRoot()); }

--- a/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
+++ b/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
@@ -225,15 +225,7 @@ public abstract class Options {
 		}
 		
 		public MavenBundle forThisPlatform() {
-			String name = System.getProperty("os.name").toLowerCase();
-			if (name.startsWith("windows"))
-				return classifier("windows");
-			else if (name.startsWith("mac os x"))
-				return classifier("mac");
-			else if (name.startsWith("linux"))
-				return classifier("linux");
-			else
-				throw new RuntimeException("Unsupported OS: " + name);
+			return classifier(thisPlatform());
 		}
 		
 		public MavenBundle version(String version) {
@@ -352,11 +344,15 @@ public abstract class Options {
 					try {
 						String groupId = dep.getGroupId();
 						String artifactId = dep.getArtifactId();
+						String classifier = dep.getClassifier();
 						if (// these should not be runtime dependencies -> fix in POMs
 							!(groupId.equals("org.osgi") && (artifactId.equals("org.osgi.compendium") || artifactId.equals("org.osgi.core")))
 							// fragment bundles not supported
 							&& !(groupId.equals("org.slf4j") && artifactId.equals("slf4j-jdk14"))
 							) {
+							if ((classifier.equals("linux") || classifier.equals("mac") || classifier.equals("windows")))
+								if (!classifier.equals(thisPlatform()))
+									continue;
 							if (!(groupId.equals("org.daisy.xprocspec") && artifactId.equals("xprocspec")))
 								validateBundle(dep.getFile());
 							list.add(new MavenBundle(dep)); }}
@@ -438,5 +434,17 @@ public abstract class Options {
 				b.append(classifier).append(":"); }
 		b.append(version);
 		return b.toString();
+	}
+	
+	private static String thisPlatform() {
+		String name = System.getProperty("os.name").toLowerCase();
+		if (name.startsWith("windows"))
+			return "windows";
+		else if (name.startsWith("mac os x"))
+			return "mac";
+		else if (name.startsWith("linux"))
+			return "linux";
+		else
+			throw new RuntimeException("Unsupported OS: " + name);
 	}
 }

--- a/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
+++ b/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
@@ -326,9 +326,10 @@ public abstract class Options {
 		
 		private MavenBundlesWithDependencies(MavenBundleOption... options) {
 			fromBundles = new ArrayList<MavenBundle>();
-			for (MavenBundleOption o : options)
+			for (MavenBundleOption o : options) {
+				if (o == null) continue;
 				for (MavenBundle b : o.getBundles())
-					fromBundles.add(b);
+					fromBundles.add(b); }
 			logger.info(this.toString());
 			StringBuilder sb = new StringBuilder();
 			List<String> bundlesAsStrings = new ArrayList<String>();

--- a/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
+++ b/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
@@ -196,7 +196,7 @@ public abstract class Options {
 		
 		private String groupId = null;
 		private String artifactId = null;
-		private String type = null;
+		private String type = "jar";
 		private String classifier = null;
 		private String version = null;
 		

--- a/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
+++ b/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
@@ -2,171 +2,54 @@ package org.daisy.pipeline.pax.exam;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.io.InputStream;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.ArrayList;
+import static java.util.Collections.sort;
 import java.util.HashSet;
+import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
+
+import org.apache.maven.repository.internal.DefaultServiceLocator;
+import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 
 import static org.ops4j.pax.exam.CoreOptions.bundle;
 import static org.ops4j.pax.exam.CoreOptions.composite;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.systemPackage;
 import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
 import org.ops4j.pax.exam.MavenUtils;
 import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.options.AbstractProvisionOption;
+import org.ops4j.pax.exam.options.CompositeOption;
 import org.ops4j.pax.exam.options.MavenArtifactProvisionOption;
+import org.ops4j.pax.exam.options.MavenUrlReference.VersionResolver;
 import org.ops4j.pax.exam.options.SystemPackageOption;
 import org.ops4j.pax.exam.options.SystemPropertyOption;
 import org.ops4j.pax.exam.options.UrlProvisionOption;
 import org.ops4j.pax.exam.util.PathUtils;
 
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.collection.CollectRequest;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.repository.LocalRepository;
+import org.sonatype.aether.RepositorySystem;
+import org.sonatype.aether.resolution.DependencyRequest;
+import org.sonatype.aether.resolution.DependencyResolutionException;
+import org.sonatype.aether.util.artifact.DefaultArtifact;
+import org.sonatype.aether.util.DefaultRepositorySystemSession;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public abstract class Options {
 	
-	private static Map<String,String[]> mavenArtifacts = new HashMap<String,String[]>();
+	private static final Logger logger = LoggerFactory.getLogger(Options.class);
 	
-	static {
-		mavenArtifacts.put("ch.qos.logback.classic",                      new String[]{"ch.qos.logback", "logback-classic", "1.0.11"});
-		mavenArtifacts.put("ch.qos.logback.core",                         new String[]{"ch.qos.logback", "logback-core", "1.0.11"});
-		mavenArtifacts.put("com.xmlcalabash",                             new String[]{"org.daisy.libs", "com.xmlcalabash"});
-		mavenArtifacts.put("com.google.guava",                            new String[]{"com.google.guava", "guava"});
-		mavenArtifacts.put("com.thaiopensource.jing",                     new String[]{"org.daisy.libs", "jing"});
-		mavenArtifacts.put("javax.persistence",                           new String[]{"org.eclipse.persistence", "javax.persistence"});
-		mavenArtifacts.put("jcl.over.slf4j",                              new String[]{"org.slf4j", "jcl-over-slf4j"});
-		mavenArtifacts.put("net.sf.saxon.saxon-he",                       new String[]{"org.daisy.libs", "saxon-he"});
-		mavenArtifacts.put("org.apache.commons.codec",                    new String[]{"commons-codec", "commons-codec"});
-		mavenArtifacts.put("org.apache.httpcomponents.httpclient",        new String[]{"org.apache.httpcomponents", "httpclient-osgi"});
-		mavenArtifacts.put("org.apache.httpcomponents.httpcore",          new String[]{"org.apache.httpcomponents", "httpcore-osgi"});
-		mavenArtifacts.put("org.apache.servicemix.bundles.xmlresolver",   new String[]{"org.apache.servicemix.bundles", "org.apache.servicemix.bundles.xmlresolver"});
-		mavenArtifacts.put("org.daisy.maven.xproc-api",                   new String[]{"org.daisy.maven", "xproc-engine-api"});
-		mavenArtifacts.put("org.daisy.maven.xproc-engine-calabash",       new String[]{"org.daisy.maven", "xproc-engine-calabash"});
-		mavenArtifacts.put("org.daisy.maven.xproc-engine-daisy-pipeline", new String[]{"org.daisy.maven", "xproc-engine-daisy-pipeline"});
-		mavenArtifacts.put("org.daisy.maven.xprocspec-runner",            new String[]{"org.daisy.maven", "xprocspec-runner"});
-		mavenArtifacts.put("org.daisy.maven.xspec-runner",                new String[]{"org.daisy.maven", "xspec-runner"});
-		mavenArtifacts.put("org.daisy.pipeline.calabash-adapter",         new String[]{"org.daisy.pipeline", "calabash-adapter"});
-		mavenArtifacts.put("org.daisy.pipeline.common-utils",             new String[]{"org.daisy.pipeline", "common-utils"});
-		mavenArtifacts.put("org.daisy.pipeline.framework-core",           new String[]{"org.daisy.pipeline", "framework-core"});
-		mavenArtifacts.put("org.daisy.pipeline.modules-registry",         new String[]{"org.daisy.pipeline", "modules-registry"});
-		mavenArtifacts.put("org.daisy.pipeline.saxon-adapter",            new String[]{"org.daisy.pipeline", "saxon-adapter"});
-		mavenArtifacts.put("org.daisy.pipeline.woodstox-osgi-adapter",    new String[]{"org.daisy.pipeline", "woodstox-osgi-adapter"});
-		mavenArtifacts.put("org.daisy.pipeline.xpath-registry",           new String[]{"org.daisy.pipeline", "xpath-registry"});
-		mavenArtifacts.put("org.daisy.pipeline.xmlcatalog",               new String[]{"org.daisy.pipeline", "xmlcatalog"});
-		mavenArtifacts.put("org.daisy.pipeline.xproc-api",                new String[]{"org.daisy.pipeline", "xproc-api"});
-		mavenArtifacts.put("org.daisy.xprocspec",                         new String[]{"org.daisy.xprocspec", "xprocspec"});
-		mavenArtifacts.put("slf4j.api",                                   new String[]{"org.slf4j", "slf4j-api", "1.7.2"});
-		mavenArtifacts.put("stax2-api",                                   new String[]{"org.codehaus.woodstox", "stax2-api"});
-		mavenArtifacts.put("woodstox-core-lgpl",                          new String[]{"org.codehaus.woodstox", "woodstox-core-lgpl"});
-	}
-	
-	private static List<String> wrappedBundles = Arrays.asList("org.daisy.xprocspec");
-	
-	private static Option getMavenArtifactForBundleId(String bundleId) {
-		String[] artifact = mavenArtifacts.get(bundleId);
-		if (artifact == null)
-			throw new RuntimeException("Couldn't find a maven artifact for bundle " + bundleId);
-		MavenArtifactProvisionOption bundle = mavenBundle().groupId(artifact[0]).artifactId(artifact[1]);
-		String version = null;
-		if (artifact.length == 3) {
-			version = artifact[2];
-			bundle = bundle.version(version); }
-		if (wrappedBundles.contains(bundleId)) {
-			if (version == null) {
-				version = MavenUtils.asInProject().getVersion(artifact[0], artifact[1]);
-				bundle.version(version); }
-			return wrappedBundle(bundle).bundleSymbolicName(bundleId)
-			                            .bundleVersion(version.replaceAll("-",".")); }
-		else if (version == null)
-			return bundle.versionAsInProject();
-		else
-			return bundle;
-	}
-	
-	private static Map<String,String[]> runtimeDependencies = new HashMap<String,String[]>();
-	
-	static {
-		runtimeDependencies.put("ch.qos.logback.classic",                      new String[]{"ch.qos.logback.core",
-		                                                                                    "slf4j.api"});
-		runtimeDependencies.put("ch.qos.logback.core",                         new String[]{"slf4j.api"});
-		runtimeDependencies.put("com.xmlcalabash",                             new String[]{"net.sf.saxon.saxon-he",
-		                                                                                    "org.apache.httpcomponents.httpclient"});
-		runtimeDependencies.put("jcl.over.slf4j",                              new String[]{"slf4j.api"});
-		runtimeDependencies.put("org.apache.httpcomponents.httpclient",        new String[]{"org.apache.commons.codec",
-		                                                                                    "org.apache.httpcomponents.httpcore",
-		                                                                                    "jcl.over.slf4j"});
-		runtimeDependencies.put("org.daisy.maven.xproc-engine-calabash",       new String[]{"net.sf.saxon.saxon-he",
-		                                                                                    "org.daisy.maven.xproc-api",
-		                                                                                    "com.xmlcalabash"});
-		runtimeDependencies.put("org.daisy.maven.xproc-engine-daisy-pipeline", new String[]{"org.daisy.maven.xproc-api",
-		                                                                                    "org.daisy.pipeline.calabash-adapter", // org.daisy.common.xproc.XProcEngine (1..1)
-		                                                                                    "org.daisy.pipeline.common-utils",
-		                                                                                    "org.daisy.pipeline.xproc-api"});
-		runtimeDependencies.put("org.daisy.maven.xprocspec-runner",            new String[]{"com.google.guava",
-		                                                                                    "net.sf.saxon.saxon-he",
-		                                                                                    "org.daisy.maven.xproc-api",
-		                                                                                    "org.daisy.maven.xproc-engine-daisy-pipeline", // org.daisy.maven.xproc.api.XProcEngine (1..1)
-		                                                                                    "org.daisy.xprocspec"});
-		runtimeDependencies.put("org.daisy.maven.xspec-runner",                new String[]{"com.google.guava",
-		                                                                                    "net.sf.saxon.saxon-he",
-		                                                                                    "org.apache.servicemix.bundles.xmlresolver",
-		                                                                                    "org.daisy.pipeline.saxon-adapter"});
-		runtimeDependencies.put("org.daisy.pipeline.calabash-adapter",         new String[]{"com.google.guava",
-		                                                                                    "com.xmlcalabash",
-		                                                                                    "net.sf.saxon.saxon-he",
-		                                                                                    "org.daisy.pipeline.common-utils",
-		                                                                                    "org.daisy.pipeline.framework-core",
-		                                                                                    "org.daisy.pipeline.modules-registry", // javax.xml.transform.URIResolver (1..1)
-		                                                                                    "org.daisy.pipeline.xpath-registry",
-		                                                                                    "org.daisy.pipeline.xproc-api"});
-		runtimeDependencies.put("org.daisy.pipeline.common-utils",             new String[]{"com.google.guava",
-		                                                                                    "com.xmlcalabash",
-		                                                                                    "javax.persistence",
-		                                                                                    "slf4j.api"});
-		runtimeDependencies.put("org.daisy.pipeline.framework-core",           new String[]{"com.google.guava",
-		                                                                                    "org.daisy.pipeline.common-utils",
-		                                                                                    "org.daisy.pipeline.woodstox-osgi-adapter", // javax.xml.stream.XMLInputFactory (1..1)
-		                                                                                    "org.daisy.pipeline.xproc-api",
-		                                                                                    "slf4j.api"});
-		runtimeDependencies.put("org.daisy.pipeline.modules-registry",         new String[]{"org.daisy.pipeline.xmlcatalog",
-		                                                                                    "slf4j.api"});
-		runtimeDependencies.put("org.daisy.pipeline.saxon-adapter",            new String[]{"net.sf.saxon.saxon-he",
-		                                                                                    "org.daisy.pipeline.modules-registry", // javax.xml.transform.URIResolver (0..1)
-		                                                                                    "slf4j.api"});
-		runtimeDependencies.put("org.daisy.pipeline.woodstox-osgi-adapter",    new String[]{"woodstox-core-lgpl"});
-		runtimeDependencies.put("org.daisy.pipeline.xpath-registry",           new String[]{"net.sf.saxon.saxon-he",
-		                                                                                    "slf4j.api"});
-		runtimeDependencies.put("org.daisy.pipeline.xmlcatalog",               new String[]{"com.google.guava",
-		                                                                                    "org.daisy.pipeline.common-utils",
-		                                                                                    "org.daisy.pipeline.woodstox-osgi-adapter", // javax.xml.stream.XMLInputFactory (1..1)
-		                                                                                    "slf4j.api"});
-		runtimeDependencies.put("org.daisy.pipeline.xproc-api",                new String[]{"com.google.guava",
-		                                                                                    "org.daisy.pipeline.common-utils"});
-		runtimeDependencies.put("woodstox-core-lgpl",                          new String[]{"stax2-api"});
-	}
-	
-	private static Set<String> getRuntimeDependencies(String bundleId) {
-		Set<String> dependencies = new HashSet<String>();
-		if (runtimeDependencies.containsKey(bundleId))
-			for (String dependency : runtimeDependencies.get(bundleId)) {
-				dependencies.add(dependency);
-				dependencies.addAll(getRuntimeDependencies(dependency)); }
-		return dependencies;
-	}
-	
-	public static Option bundlesAndDependencies(String... bundles) {
-		Set<String> bundlesAndDependencies = new HashSet<String>();
-		for (String bundle : bundles) {
-			bundlesAndDependencies.add(bundle);
-			bundlesAndDependencies.addAll(getRuntimeDependencies(bundle)); }
-		Option[] options = new Option[bundlesAndDependencies.size()];
-		int i = 0;
-		for (String id : bundlesAndDependencies)
-			options[i++] = getMavenArtifactForBundleId(id);
-		return composite(options);
-	}
+	private static final File LOCAL_REPOSITORY = new File(System.getProperty("user.home"), ".m2/repository");
 	
 	public static SystemPropertyOption logbackConfigFile() {
 		return systemProperty("logback.configurationFile").value("file:" + PathUtils.getBaseDir() + "/src/test/resources/logback.xml");
@@ -183,11 +66,7 @@ public abstract class Options {
 		return systemPackage("org.w3c.dom.traversal;uses:=\"org.w3c.dom\";version=\"0.0.0.1\"");
 	}
 	
-	public static Option logbackBundles() {
-		return bundlesAndDependencies("ch.qos.logback.classic");
-	}
-	
-	public static MavenArtifactProvisionOption felixDeclarativeServices() {
+	public static MavenBundle felixDeclarativeServices() {
 		return mavenBundle().groupId("org.apache.felix").artifactId("org.apache.felix.scr").version("1.6.2");
 	}
 	
@@ -199,19 +78,30 @@ public abstract class Options {
 		);
 	}
 	
-	public static MavenArtifactProvisionOption pipelineModule(String artifactId) {
-		return mavenBundle().groupId("org.daisy.pipeline.modules").artifactId(artifactId).versionAsInProject();
+	public static MavenBundle logbackClassic() {
+		return mavenBundle("ch.qos.logback:logback-classic:1.0.11");
 	}
 	
-	public static MavenArtifactProvisionOption brailleModule(String artifactId) {
-		return mavenBundle().groupId("org.daisy.pipeline.modules.braille").artifactId(artifactId).versionAsInProject();
+	public static MavenBundleOption xprocspec() {
+		return mavenBundleComposite(
+			mavenBundle("org.daisy.maven:xprocspec-runner:?"),
+			mavenBundle("org.daisy.xprocspec:xprocspec:?")
+		);
+	}
+	
+	public static MavenBundle xspec() {
+		return mavenBundle("org.daisy.maven:xspec-runner:?");
 	}
 	
 	public static UrlProvisionOption thisBundle() {
 		File classes = new File(PathUtils.getBaseDir() + "/target/classes");
 		Manifest manifest;
 		try {
-			manifest = new Manifest(new File(classes, "META-INF/MANIFEST.MF").toURI().toURL().openStream()); }
+			InputStream stream = new File(classes, "META-INF/MANIFEST.MF").toURI().toURL().openStream();
+			try {
+				manifest = new Manifest(stream); }
+			finally {
+				stream.close(); }}
 		catch (IOException e) {
 			throw new RuntimeException(e); }
 		String components = manifest.getMainAttributes().getValue("Service-Component");
@@ -227,23 +117,303 @@ public abstract class Options {
 		return bundle("reference:" + classes.toURI());
 	}
 	
-	public static MavenArtifactProvisionOption forThisPlatform(MavenArtifactProvisionOption bundle) {
-		String name = System.getProperty("os.name").toLowerCase();
-		if (name.startsWith("windows"))
-			return bundle.classifier("windows");
-		else if (name.startsWith("mac os x"))
-			return bundle.classifier("mac");
-		else if (name.startsWith("linux"))
-			return bundle.classifier("linux");
-		else
-			throw new RuntimeException("Unsupported OS: " + name);
+	public static MavenBundle pipelineModule(String artifactId) {
+		return mavenBundle().groupId("org.daisy.pipeline.modules").artifactId(artifactId);
 	}
 	
-	public static Option xprocspecBundles() {
-		return bundlesAndDependencies("org.daisy.maven.xprocspec-runner");
+	public static MavenBundle brailleModule(String artifactId) {
+		return mavenBundle().groupId("org.daisy.pipeline.modules.braille").artifactId(artifactId);
 	}
 	
-	public static Option xspecBundles() {
-		return bundlesAndDependencies("org.daisy.maven.xspec-runner");
+	public static MavenBundle mavenBundle() {
+		return new MavenBundle();
+	}
+	
+	/**
+	 * @param artifactCoords must be a string of the form
+	 *    <groupId>:<artifactId>[:<extension>[:<classifier>]]:<version>. The default <extension> is
+	 *    "jar". When <version> is "?", the version as declared in the project is used.
+	 */
+	public static MavenBundle mavenBundle(String artifactCoords) {
+		return new MavenBundle(artifactFromCoords(artifactCoords));
+	}
+	
+	public static interface MavenBundleOption extends Option {
+		public MavenBundle[] getBundles();
+	}
+	
+	public static class MavenBundle extends AbstractProvisionOption<MavenBundle> implements MavenBundleOption {
+		
+		private MavenBundle() {}
+		
+		private MavenBundle(Artifact artifact) {
+			groupId(artifact.getGroupId());
+			artifactId(artifact.getArtifactId());
+			type(artifact.getExtension());
+			classifier(artifact.getClassifier());
+			version(artifact.getVersion());
+		}
+		
+		private String url = null;
+		
+		public String getURL() {
+			if (url == null) {
+				MavenArtifactProvisionOption bundle = new MavenArtifactProvisionOption();
+				bundle.groupId(groupId);
+				bundle.artifactId(artifactId);
+				if (type != null)
+					bundle.type(type);
+				if (classifier != null && !"".equals(classifier))
+					bundle.classifier(classifier);
+				if (version == null || version.equals("?"))
+					version(versionAsInProject.getVersion(groupId, artifactId));
+				bundle.version(version);
+				// special handling of xprocspec
+				if (groupId.equals("org.daisy.xprocspec") && artifactId.equals("xprocspec"))
+					url = wrappedBundle(bundle)
+						.bundleSymbolicName("org.daisy.xprocspec")
+						.bundleVersion(version.replaceAll("-","."))
+						.getURL();
+				else
+					url = bundle.getURL(); }
+			return url;
+		}
+		
+		public MavenBundle[] getBundles() {
+			return new MavenBundle[]{this};
+		}
+			
+		public MavenBundle itself() {
+			return this;
+		}
+		
+		private String groupId = null;
+		private String artifactId = null;
+		private String type = null;
+		private String classifier = null;
+		private String version = null;
+		
+		public MavenBundle groupId(String groupId) {
+			checkURLResolved();
+			this.groupId = groupId;
+			return this;
+		}
+		
+		public MavenBundle artifactId(String artifactId) {
+			checkURLResolved();
+			this.artifactId = artifactId;
+			return this;
+		}
+		
+		public MavenBundle type(String type) {
+			checkURLResolved();
+			this.type = type;
+			return this;
+		}
+		
+		public MavenBundle classifier(String classifier) {
+			checkURLResolved();
+			this.classifier = classifier;
+			return this;
+		}
+		
+		public MavenBundle forThisPlatform() {
+			String name = System.getProperty("os.name").toLowerCase();
+			if (name.startsWith("windows"))
+				return classifier("windows");
+			else if (name.startsWith("mac os x"))
+				return classifier("mac");
+			else if (name.startsWith("linux"))
+				return classifier("linux");
+			else
+				throw new RuntimeException("Unsupported OS: " + name);
+		}
+		
+		public MavenBundle version(String version) {
+			checkURLResolved();
+			this.version = version;
+			return this;
+		}
+		
+		private Artifact asArtifact() {
+			getURL();
+			return new DefaultArtifact(groupId, artifactId, classifier, type, version);
+		}
+		
+		private void checkURLResolved() {
+			if (url != null)
+				throw new RuntimeException();
+		}
+		
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append("mavenBundle(\"").append(artifactCoords(asArtifact())).append("\")");
+			return sb.toString();
+		}
+	}
+	
+	private static MavenBundleOption mavenBundleComposite(final MavenBundleOption... options) {
+		final MavenBundle[] bundles; {
+			List<MavenBundle> list = new ArrayList<MavenBundle>();
+			for (MavenBundleOption o : options)
+				for (MavenBundle b : o.getBundles())
+					list.add(b);
+			bundles = list.toArray(new MavenBundle[list.size()]); }
+		return new MavenBundleCompositeOption() {
+			public MavenBundle[] getBundles() {
+				return bundles;
+			}
+			@Override
+			public String toString() {
+				StringBuilder sb = new StringBuilder();
+				sb.append("compositeMavenBundleOption(");
+				int i = 0;
+				for (MavenBundleOption b : bundles) {
+					if (i > 0) sb.append(",");
+					sb.append("\n	").append(b);
+					i++; }
+				sb.append(")");
+				return sb.toString();
+			}
+		};
+	}
+	
+	private static abstract class MavenBundleCompositeOption implements MavenBundleOption, CompositeOption {
+		public MavenBundle[] getOptions() {
+			return getBundles();
+		}
+	}
+	
+	public static MavenBundleOption mavenBundlesWithDependencies(MavenBundleOption... options) {
+		return new MavenBundlesWithDependencies(options);
+	}
+	
+	private static class MavenBundlesWithDependencies extends MavenBundleCompositeOption {
+		
+		private final List<MavenBundle> fromBundles;
+		
+		private MavenBundlesWithDependencies(MavenBundleOption... options) {
+			fromBundles = new ArrayList<MavenBundle>();
+			for (MavenBundleOption o : options)
+				for (MavenBundle b : o.getBundles())
+					fromBundles.add(b);
+			logger.info(this.toString());
+			StringBuilder sb = new StringBuilder();
+			List<String> bundlesAsStrings = new ArrayList<String>();
+			for (MavenBundle b : getBundles())
+				bundlesAsStrings.add(b.toString());
+			sort(bundlesAsStrings);
+			sb.append("resolved to: MavenBundle[]{");
+			int i = 0;
+			for (String b : bundlesAsStrings) {
+				if (i > 0) sb.append(",");
+				sb.append("\n	").append(b);
+				i++; }
+			sb.append("}");
+			logger.info(sb.toString());
+		}
+		
+		private MavenBundle[] bundles = null;
+		
+		public MavenBundle[] getBundles() {
+			if (bundles == null) {
+				CollectRequest request = new CollectRequest();
+				for (MavenBundle bundle : fromBundles) {
+					request.addDependency(new Dependency(bundle.asArtifact(), "compile")); }
+				request.setRequestContext("runtime");
+				RepositorySystem system = new DefaultServiceLocator().getService(RepositorySystem.class);
+				DefaultRepositorySystemSession session = new MavenRepositorySystemSession()
+					.setLocalRepositoryManager(
+						system.newLocalRepositoryManager(
+							new LocalRepository(LOCAL_REPOSITORY.getAbsolutePath())))
+					.setOffline(true);
+				Set<Artifact> deps = new HashSet<Artifact>();
+				try {
+					addDependencies(deps, system.resolveDependencies(session, new DependencyRequest().setCollectRequest(request)).getRoot()); }
+				catch (DependencyResolutionException e) {
+					throw new RuntimeException(e); }
+				List<MavenBundle> list = new ArrayList<MavenBundle>();
+				for (Artifact dep : deps)
+					try {
+						String groupId = dep.getGroupId();
+						String artifactId = dep.getArtifactId();
+						if (// these should not be runtime dependencies -> fix in POMs
+							!(groupId.equals("org.osgi") && (artifactId.equals("org.osgi.compendium") || artifactId.equals("org.osgi.core")))
+							// fragment bundles not supported
+							&& !(groupId.equals("org.slf4j") && artifactId.equals("slf4j-jdk14"))
+							) {
+							if (!(groupId.equals("org.daisy.xprocspec") && artifactId.equals("xprocspec")))
+								validateBundle(dep.getFile());
+							list.add(new MavenBundle(dep)); }}
+					catch(Exception e) {}
+				bundles = list.toArray(new MavenBundle[list.size()]);
+			}
+			return bundles;
+		}
+		
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			sb.append("mavenBundlesWithDependencies(");
+			int i = 0;
+			for (MavenBundle b : fromBundles) {
+				if (i > 0) sb.append(",");
+				sb.append("\n	").append(b);
+				i++; }
+			sb.append(")");
+			return sb.toString();
+		}
+		
+		private static void addDependencies(Set<Artifact> deps, DependencyNode node) {
+			Dependency dep = node.getDependency();
+			if (dep != null)
+				deps.add(dep.getArtifact());
+			for (DependencyNode n : node.getChildren())
+				addDependencies(deps, n);
+		}
+		
+		private static void validateBundle(File bundle) {
+			JarFile jar = null;
+			try {
+				jar = new JarFile(bundle, false);
+				Manifest manifest = jar.getManifest();
+				if (manifest == null)
+					throw new RuntimeException("[" + bundle + "] is not a valid bundle: manifest is missing");
+				String bundleSymbolicName = manifest.getMainAttributes().getValue("Bundle-SymbolicName");
+				String bundleName = manifest.getMainAttributes().getValue("Bundle-Name");
+				if (bundleSymbolicName == null && bundleName == null) {
+					throw new RuntimeException("[" + bundle + "] is not a valid bundle: Bundle-SymbolicName and Bundle-Name are missing"); }}
+			catch (IOException e) {
+				throw new RuntimeException("[" + bundle + "] is not a valid bundle: failed reading jar", e); }
+			finally {
+				if (jar != null)
+					try {
+						jar.close(); }
+					catch (IOException e) {}}
+		}
+	}
+	
+	private static final VersionResolver versionAsInProject = MavenUtils.asInProject();
+	
+	private static Artifact artifactFromCoords(String coords) {
+		return new DefaultArtifact(coords);
+	}
+	
+	private static String artifactCoords(Artifact artifact) {
+		String groupId = artifact.getGroupId();
+		String artifactId = artifact.getArtifactId();
+		String extension = artifact.getExtension();
+		String classifier = artifact.getClassifier();
+		String version = artifact.getVersion();
+		StringBuilder b = new StringBuilder()
+			.append(groupId).append(":")
+			.append(artifactId).append(":");
+		if (!extension.equals("jar") || !classifier.equals("")) {
+			b.append(extension).append(":");
+			if (!classifier.equals(""))
+				b.append(classifier).append(":"); }
+		b.append(version);
+		return b.toString();
 	}
 }

--- a/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
+++ b/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
@@ -423,11 +423,11 @@ public abstract class Options {
 									versionAsInProject = b.versionAsInProject;
 									break; }
 							if (versionAsInProject
-							    && !a.getVersion().equals(MavenUtils.asInProject().getVersion(groupId, artifactId))) {
+							    && !a.getBaseVersion().equals(MavenUtils.asInProject().getVersion(groupId, artifactId))) {
 								MavenBundle b = new MavenBundle(a, true);
 								logger.info("Forcing transitive dependency \"" + artifactCoords(b.asArtifact()) + "\" (version as in project) "
-								            + "because it would otherwise resolve to version \"" + a.getVersion() + "\" "
-								            + "(through \"" + artifactCoords(parent) + "\")");
+								            + "because it would otherwise resolve to version \"" + a.getBaseVersion() + "\" "
+								            + "(via \"" + artifactCoords(parent) + "\")");
 								fromBundles.add(b);
 								return false; }
 							bundles.add(new MavenBundle(a)); }}}

--- a/pax-exam-helper/src/test/java/org/daisy/pipeline/pax/exam/OptionsTest.java
+++ b/pax-exam-helper/src/test/java/org/daisy/pipeline/pax/exam/OptionsTest.java
@@ -1,0 +1,27 @@
+package org.daisy.pipeline.pax.exam;
+
+import java.util.ArrayList;
+import static java.util.Collections.sort;
+import java.util.List;
+
+import static org.daisy.pipeline.pax.exam.Options.logbackClassic;
+import static org.daisy.pipeline.pax.exam.Options.mavenBundlesWithDependencies;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import org.ops4j.pax.exam.Option;
+
+public class OptionsTest {
+	
+	@Test
+	public void testLogbackClassicWithDependencies() {
+		List<String> bundles = new ArrayList<String>();
+		for (Option b : mavenBundlesWithDependencies(logbackClassic()).getBundles())
+			bundles.add(b.toString());
+		sort(bundles);
+		assertEquals(bundles.get(0).toString(), "mavenBundle(\"ch.qos.logback:logback-classic:1.0.11\")");
+		assertEquals(bundles.get(1).toString(), "mavenBundle(\"ch.qos.logback:logback-core:1.0.11\")");
+		assertEquals(bundles.get(2).toString(), "mavenBundle(\"org.slf4j:slf4j-api:1.7.4\")");
+	}
+}


### PR DESCRIPTION
...using the Sonatype Aether library. For this to work all runtime
dependencies must be declared in the POMs. Thanks to this change the
pax-exam-helper will work with any (future) version of the
Pipeline. Therefore it is no use anymore that the version number matches
the main Pipeline version.