### PR TITLE
No special handling of xprocspec

### DIFF
--- a/modules-test-helper/pom.xml
+++ b/modules-test-helper/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.daisy</groupId>
+    <artifactId>daisy</artifactId>
+    <version>4</version>
+    <relativePath />
+  </parent>
+
+  <groupId>org.daisy.pipeline.build</groupId>
+  <artifactId>modules-test-helper</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>bundle</packaging>
+
+  <name>DAISY Pipeline 2 :: Modules Test Helper</name>
+  
+  <properties>
+    <pax-exam.version>3.3.0</pax-exam.version>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.maven</groupId>
+      <artifactId>xprocspec-runner</artifactId>
+      <version>1.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.maven</groupId>
+      <artifactId>xspec-runner</artifactId>
+      <version>1.0.1-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.pipeline</groupId>
+      <artifactId>pax-exam-helper</artifactId>
+      <version>2.1.2-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.xprocspec</groupId>
+      <artifactId>xprocspec</artifactId>
+      <version>1.1.0</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.maven</groupId>
+      <artifactId>xproc-engine-daisy-pipeline</artifactId>
+      <version>1.10.3-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+      <version>1.3.04</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.pipeline</groupId>
+      <artifactId>saxon-adapter</artifactId>
+      <version>1.2-SNAPSHOT</version>
+      <scope>runtime</scope>
+    </dependency>
+    <!--
+        for pax-exam annotations
+    -->
+    <!--
+        org.ops4j.pax.exam.spi.reactors
+    -->
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-spi</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <!--
+        org.ops4j.pax.exam.junit
+    -->
+    <dependency>
+      <groupId>org.ops4j.pax.exam</groupId>
+      <artifactId>pax-exam-junit4</artifactId>
+      <version>${pax-exam.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.4.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <archive>
+            <addMavenDescriptor>false</addMavenDescriptor>
+          </archive>
+          <instructions>
+            <Import-Package>
+              org.daisy.maven.xproc.xprocspec;resolution:=optional,
+              org.daisy.maven.xspec;resolution:=optional,
+              org.ops4j.pax.exam.junit;resolution:=optional,
+              org.daisy.pipeline.pax.exam;resolution:=optional,
+              org.ops4j.pax.exam.spi.reactors;resolution:=optional,
+              *
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+</project>

--- a/modules-test-helper/pom.xml
+++ b/modules-test-helper/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.daisy.xprocspec</groupId>
       <artifactId>xprocspec</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/modules-test-helper/src/main/java/org/daisy/pipeline/junit/AbstractTest.java
+++ b/modules-test-helper/src/main/java/org/daisy/pipeline/junit/AbstractTest.java
@@ -1,0 +1,66 @@
+package org.daisy.pipeline.junit;
+
+import static org.daisy.pipeline.pax.exam.Options.domTraversalPackage;
+import static org.daisy.pipeline.pax.exam.Options.felixDeclarativeServices;
+import static org.daisy.pipeline.pax.exam.Options.logbackClassic;
+import static org.daisy.pipeline.pax.exam.Options.logbackConfigFile;
+import org.daisy.pipeline.pax.exam.Options.MavenBundleOption;
+import static org.daisy.pipeline.pax.exam.Options.mavenBundle;
+import static org.daisy.pipeline.pax.exam.Options.mavenBundles;
+import static org.daisy.pipeline.pax.exam.Options.mavenBundlesWithDependencies;
+import static org.daisy.pipeline.pax.exam.Options.thisBundle;
+
+import org.junit.runner.RunWith;
+
+import org.ops4j.pax.exam.Configuration;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.systemPackage;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public abstract class AbstractTest {
+	
+	protected String[] testDependencies() {
+		return new String[]{};
+	}
+	
+	protected String pipelineModule(String module) {
+		return "org.daisy.pipeline.modules:" + module + ":?";
+	}
+	
+	protected String brailleModule(String module) {
+		return "org.daisy.pipeline.modules.braille:" + module + ":?";
+	}
+	
+	@Configuration
+	public Option[] config() {
+		return _.config(
+			logbackConfigFile(),
+			mavenBundles(testDependencies()));
+	}
+	
+	// wrapped in class to avoid ClassNotFoundException
+	protected static abstract class _ {
+		protected static Option[] config(Option systemProperties, MavenBundleOption testDependencies) {
+			return options(
+				systemProperties,
+				domTraversalPackage(),
+				felixDeclarativeServices(),
+				thisBundle(),
+				junitBundles(),
+				systemPackage("javax.xml.stream;version=\"1.0.1\""),
+				mavenBundle("org.daisy.pipeline.build:modules-test-helper:?"),
+				mavenBundlesWithDependencies(
+					testDependencies,
+					// logging
+					logbackClassic(),
+					mavenBundle("org.slf4j:jcl-over-slf4j:1.7.2"))
+			);
+		}
+	}
+}

--- a/modules-test-helper/src/main/java/org/daisy/pipeline/junit/AbstractXSpecAndXProcSpecTest.java
+++ b/modules-test-helper/src/main/java/org/daisy/pipeline/junit/AbstractXSpecAndXProcSpecTest.java
@@ -1,0 +1,77 @@
+package org.daisy.pipeline.junit;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.daisy.maven.xproc.xprocspec.XProcSpecRunner;
+import org.daisy.maven.xspec.TestResults;
+import org.daisy.maven.xspec.XSpecRunner;
+
+import static org.daisy.pipeline.pax.exam.Options.calabashConfigFile;
+import static org.daisy.pipeline.pax.exam.Options.logbackConfigFile;
+import static org.daisy.pipeline.pax.exam.Options.mavenBundle;
+import static org.daisy.pipeline.pax.exam.Options.mavenBundles;
+import static org.daisy.pipeline.pax.exam.Options.xprocspec;
+import static org.daisy.pipeline.pax.exam.Options.xspec;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import org.ops4j.pax.exam.Configuration;
+import static org.ops4j.pax.exam.CoreOptions.composite;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.util.PathUtils;
+
+public abstract class AbstractXSpecAndXProcSpecTest extends AbstractTest {
+	
+	@Inject
+	protected XSpecRunner xspecRunner;
+	
+	@Test
+	public void runXSpec() throws Exception {
+		File baseDir = new File(PathUtils.getBaseDir());
+		File testsDir = new File(baseDir, "src/test/xspec");
+		if (testsDir.exists()) {
+			File reportsDir = new File(baseDir, "target/surefire-reports");
+			reportsDir.mkdirs();
+			TestResults result = xspecRunner.run(testsDir, reportsDir);
+			assertEquals("Number of failures and errors should be zero", 0L, result.getFailures() + result.getErrors());
+		}
+	}
+	
+	@Inject
+	protected XProcSpecRunner xprocspecRunner;
+	
+	@Test
+	public void runXProcSpec() throws Exception {
+		File baseDir = new File(PathUtils.getBaseDir());
+		File testsDir = new File(baseDir, "src/test/xprocspec");
+		if (testsDir.exists()) {
+			boolean success = xprocspecRunner.run(testsDir,
+			                                      new File(baseDir, "target/xprocspec-reports"),
+			                                      new File(baseDir, "target/surefire-reports"),
+			                                      new File(baseDir, "target/xprocspec"),
+			                                      new XProcSpecRunner.Reporter.DefaultReporter());
+			assertTrue("XProcSpec tests should run with success", success);
+		}
+	}
+	
+	@Override @Configuration
+	public Option[] config() {
+		return _.config(
+			composite(
+				logbackConfigFile(),
+				calabashConfigFile()),
+			mavenBundles(
+				mavenBundles(testDependencies()),
+				// xprocspec
+				xprocspec(),
+				mavenBundle("org.daisy.maven:xproc-engine-daisy-pipeline:?"),
+				// xspec
+				xspec(),
+				mavenBundle("org.daisy.pipeline:saxon-adapter:?"))
+		);
+	}
+}

--- a/pax-exam-helper/pom.xml
+++ b/pax-exam-helper/pom.xml
@@ -26,6 +26,10 @@
     <aether.version>1.13.1</aether.version>
     <maven.version>3.0.4</maven.version>
     <wagon.version>2.2</wagon.version>
+    <xspec-runner.version>1.0.1-SNAPSHOT</xspec-runner.version>
+    <xprocspec.version>1.1.0</xprocspec.version>
+    <xprocspec-runner.version>1.0.0</xprocspec-runner.version>
+    <xproc-engine-daisy-pipeline.version>1.10</xproc-engine-daisy-pipeline.version>
   </properties>
   
   <dependencies>
@@ -135,6 +139,33 @@
       <version>1</version>
       <scope>runtime</scope>
     </dependency>
+    <!--
+        test dependencies for integration tests
+    -->
+    <dependency>
+      <groupId>org.daisy.maven</groupId>
+      <artifactId>xspec-runner</artifactId>
+      <version>${xspec-runner.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.maven</groupId>
+      <artifactId>xproc-engine-daisy-pipeline</artifactId>
+      <version>${xproc-engine-daisy-pipeline.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.xprocspec</groupId>
+      <artifactId>xprocspec</artifactId>
+      <version>${xprocspec.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.daisy.maven</groupId>
+      <artifactId>xprocspec-runner</artifactId>
+      <version>${xprocspec-runner.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
   <build>
@@ -196,10 +227,10 @@
               <postBuildHookScript>verify</postBuildHookScript>
               <properties>
                 <pax-exam-helper.version>${project.version}</pax-exam-helper.version>
-                <xspec-runner.version>1.0.0</xspec-runner.version>
-                <xprocspec.version>1.1.0</xprocspec.version>
-                <xprocspec-runner.version>1.0.0</xprocspec-runner.version>
-                <xproc-engine-daisy-pipeline.version>1.10</xproc-engine-daisy-pipeline.version>
+                <xspec-runner.version>${xspec-runner.version}</xspec-runner.version>
+                <xprocspec.version>${xprocspec.version}</xprocspec.version>
+                <xprocspec-runner.version>${xprocspec-runner.version}</xprocspec-runner.version>
+                <xproc-engine-daisy-pipeline.version>${xproc-engine-daisy-pipeline.version}</xproc-engine-daisy-pipeline.version>
               </properties>
               <goals>
                 <goal>clean</goal>

--- a/pax-exam-helper/src/it/it-pax-exam-xprocspec/pom.xml
+++ b/pax-exam-helper/src/it/it-pax-exam-xprocspec/pom.xml
@@ -14,16 +14,6 @@
       <artifactId>xproc-engine-daisy-pipeline</artifactId>
       <version>${xproc-engine-daisy-pipeline.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-jdk14</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.daisy.xprocspec</groupId>

--- a/pax-exam-helper/src/it/it-pax-exam-xspec/pom.xml
+++ b/pax-exam-helper/src/it/it-pax-exam-xspec/pom.xml
@@ -14,16 +14,6 @@
       <artifactId>saxon-adapter</artifactId>
       <version>1.1</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-jdk14</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.daisy.maven</groupId>
@@ -36,12 +26,6 @@
           <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.xmlresolver</artifactId>
-      <version>1.2_5</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.daisy.pipeline</groupId>

--- a/pax-exam-helper/src/it/it-pax-exam-xspec/pom.xml
+++ b/pax-exam-helper/src/it/it-pax-exam-xspec/pom.xml
@@ -49,15 +49,6 @@
       <version>${pax-exam-helper.version}</version>
       <scope>test</scope>
     </dependency>
-    <!--
-        force Maven to use the latest common-utils
-    -->
-    <dependency>
-      <groupId>org.daisy.pipeline</groupId>
-      <artifactId>common-utils</artifactId>
-      <version>2.1.1</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   
   <build>

--- a/pax-exam-helper/src/it/it-pax-exam-xspec/src/test/java/XSpecTest.java
+++ b/pax-exam-helper/src/it/it-pax-exam-xspec/src/test/java/XSpecTest.java
@@ -40,7 +40,6 @@ public class XSpecTest {
 				logbackClassic(),
 				// xspec
 				xspec(),
-				mavenBundle("org.apache.servicemix.bundles:org.apache.servicemix.bundles.xmlresolver:?"),
 				mavenBundle("org.daisy.pipeline:saxon-adapter:?")),
 			junitBundles()
 		);

--- a/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
+++ b/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
@@ -192,7 +192,8 @@ public abstract class Options {
 						logger.error("Could not find version of " + groupId + ":" + artifactId + " in Maven project");
 						throw new RuntimeException("Could not find version of " + groupId + ":" + artifactId + " in Maven project"); }
 				bundle.version(version);
-				// special handling of xprocspec
+				// FIXME: special handling of xprocspec
+				// xprocspec 1.2.0 is a bundle but does not export resources
 				if (groupId.equals("org.daisy.xprocspec") && artifactId.equals("xprocspec"))
 					url = wrappedBundle(bundle)
 						.bundleSymbolicName("org.daisy.xprocspec")

--- a/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
+++ b/pax-exam-helper/src/main/java/org/daisy/pipeline/pax/exam/Options.java
@@ -92,7 +92,7 @@ public abstract class Options {
 	}
 	
 	public static MavenBundleOption xprocspec() {
-		return mavenBundleComposite(
+		return mavenBundles(
 			mavenBundle("org.daisy.maven:xprocspec-runner:?"),
 			mavenBundle("org.daisy.xprocspec:xprocspec:?")
 		);
@@ -294,12 +294,13 @@ public abstract class Options {
 		}
 	}
 	
-	private static MavenBundleOption mavenBundleComposite(final MavenBundleOption... options) {
+	public static MavenBundleOption mavenBundles(final MavenBundleOption... options) {
 		final MavenBundle[] bundles; {
 			List<MavenBundle> list = new ArrayList<MavenBundle>();
 			for (MavenBundleOption o : options)
-				for (MavenBundle b : o.getBundles())
-					list.add(b);
+				if (o != null)
+					for (MavenBundle b : o.getBundles())
+						list.add(b);
 			bundles = list.toArray(new MavenBundle[list.size()]); }
 		return new MavenBundleCompositeOption() {
 			public MavenBundle[] getBundles() {
@@ -318,6 +319,13 @@ public abstract class Options {
 				return sb.toString();
 			}
 		};
+	}
+	
+	public static MavenBundleOption mavenBundles(final String... artifactCoords) {
+		MavenBundle[] bundles = new MavenBundle[artifactCoords.length];
+		for (int i = 0; i < artifactCoords.length; i++)
+			bundles[i] = artifactCoords == null ? null : mavenBundle(artifactCoords[i]);
+		return mavenBundles(bundles);
 	}
 	
 	private static abstract class MavenBundleCompositeOption implements MavenBundleOption, CompositeOption {
@@ -512,7 +520,7 @@ public abstract class Options {
 		return b.toString();
 	}
 	
-	private static String thisPlatform() {
+	public static String thisPlatform() {
 		String name = System.getProperty("os.name").toLowerCase();
 		if (name.startsWith("windows"))
 			return "windows";

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   <modules>
     <module>modules-parent</module>
     <module>modules-build-helper</module>
+    <module>modules-test-helper</module>
     <module>saxon-adapter</module>
     <module>pax-exam-helper</module>
     <module>archetypes</module>

--- a/saxon-adapter/pom.xml
+++ b/saxon-adapter/pom.xml
@@ -39,34 +39,20 @@
       <artifactId>slf4j-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.daisy.libs</groupId>
-      <artifactId>saxon-he</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.daisy.pipeline</groupId>
-      <artifactId>woodstox-osgi-adapter</artifactId>
-      <scope>runtime</scope>
-    </dependency>
+    <!--
+        runtime dependencies (for javax.xml.transform.URIResolver)
+    -->
     <dependency>
       <groupId>org.daisy.pipeline</groupId>
       <artifactId>modules-registry</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <!--
+        runtime dependencies (OSGi) (FIXME: use for compilation)
+    -->
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-osgi</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore-osgi</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.persistence</groupId>
-      <artifactId>javax.persistence</artifactId>
+      <groupId>org.daisy.libs</groupId>
+      <artifactId>saxon-he</artifactId>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/saxon-adapter/pom.xml
+++ b/saxon-adapter/pom.xml
@@ -31,8 +31,8 @@
   
   <dependencies>
     <dependency>
-      <groupId>net.sf.saxon</groupId>
-      <artifactId>Saxon-HE</artifactId>
+      <groupId>org.daisy.libs</groupId>
+      <artifactId>saxon-he</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -45,14 +45,6 @@
     <dependency>
       <groupId>org.daisy.pipeline</groupId>
       <artifactId>modules-registry</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <!--
-        runtime dependencies (OSGi) (FIXME: use for compilation)
-    -->
-    <dependency>
-      <groupId>org.daisy.libs</groupId>
-      <artifactId>saxon-he</artifactId>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/saxon-adapter/pom.xml
+++ b/saxon-adapter/pom.xml
@@ -22,7 +22,7 @@
       <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>framework-bom</artifactId>
-        <version>1.8.1</version>
+        <version>1.10.3-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>org.daisy.libs</groupId>
       <artifactId>saxon-he</artifactId>
-      <version>9.5.1.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -58,19 +57,16 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
-      <version>4.2.5</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore-osgi</artifactId>
-      <version>4.2.4</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>javax.persistence</artifactId>
-      <version>2.0.3</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
because it is an OSGi bundle now. Assumes that xprocspec version >= [1.2.0](https://github.com/daisy/xprocspec/releases/tag/v1.2.0) is used.