### PR TITLE
process-catalog: fix inheriting from a script that inherits from another script

### DIFF
--- a/modules-build-helper/src/main/resources/lib/extend-script.xsl
+++ b/modules-build-helper/src/main/resources/lib/extend-script.xsl
@@ -22,7 +22,7 @@
                 <xsl:when test="$extends-uri-element/@px:extends">
                     <xsl:variable name="doc">
                         <xsl:call-template name="extend-script">
-                            <xsl:with-param name="script-uri" select="$extends-uri"/>
+                            <xsl:with-param name="script-uri" select="$extends-uri-element/resolve-uri(@uri,base-uri(.))"/>
                             <xsl:with-param name="extends-uri" select="$extends-uri-element/resolve-uri(@px:extends,base-uri(.))"/>
                             <xsl:with-param name="catalog-xml" select="$catalog-xml"/>
                         </xsl:call-template>

--- a/modules-parent/pom.xml
+++ b/modules-parent/pom.xml
@@ -138,7 +138,7 @@
         <plugin>
           <groupId>org.daisy.pipeline.build</groupId>
           <artifactId>modules-build-helper</artifactId>
-          <version>2.0.0</version>
+          <version>2.0.1-SNAPSHOT</version>
         </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>


### PR DESCRIPTION
This was originally implemented in https://github.com/daisy/pipeline-mod-braille/commit/95b632d but then later broken by commit 4eade60.

There is also an alternate fix https://github.com/nlbdev/pipeline/commit/3d5104ae48fdb9ccd4d592b27c4c75e8109d9162.