### PR TITLE
modules-build-helper: add a goal to create a package-list file

### DIFF
--- a/modules-build-helper/pom.xml
+++ b/modules-build-helper/pom.xml
@@ -61,8 +61,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>3.0-alpha-2</version>
+      <artifactId>maven-core</artifactId>
+      <version>3.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>

--- a/modules-build-helper/src/it/it-pipeline-module/pom.xml
+++ b/modules-build-helper/src/it/it-pipeline-module/pom.xml
@@ -19,6 +19,13 @@
   <artifactId>it-pipeline-module</artifactId>
   <version>0-SNAPSHOT</version>
   <packaging>bundle</packaging>
+  <dependencies>
+    <dependency>
+      <artifactId>calabash-adapter</artifactId>
+      <groupId>org.daisy.pipeline</groupId>
+      <version>2.0.5</version>
+    </dependency>
+  </dependencies>
   <build>
     <pluginManagement>
       <plugins>
@@ -38,6 +45,26 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.daisy.pipeline.build</groupId>
+        <artifactId>modules-build-helper</artifactId>
+        <executions>
+          <execution>
+            <id>package-list</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>dependencies-package-list</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/dependencies-package-list/</outputDirectory>
+              <includes>
+                org.daisy.pipeline.*,
+                org.daisy.common.*
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.daisy.maven</groupId>
         <artifactId>xproc-maven-plugin</artifactId>
@@ -66,6 +93,26 @@
             <version>${xprocspec.version}</version>
           </dependency>
         </dependencies>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>javadoc</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <offlineLinks>
+                <offlineLink>
+                  <url>http://daisy.github.io/pipeline/api/</url>
+                  <location>${project.build.directory}/dependencies-package-list/</location>
+                </offlineLink>
+              </offlineLinks>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/modules-build-helper/src/it/it-pipeline-module/src/it/xprocspec/test.xprocspec
+++ b/modules-build-helper/src/it/it-pipeline-module/src/it/xprocspec/test.xprocspec
@@ -28,6 +28,9 @@
 					<c:file name="META-INF/catalog.xml"/>
 					<c:file name="OSGI-INF/script.xml"/>
 					<c:file name="css/foo.css"/>
+					<c:file name="impl/JavaStep$1.class"/>
+					<c:file name="impl/JavaStep$Provider.class"/>
+					<c:file name="impl/JavaStep.class"/>
 					<c:file name="xml/foo.xsl"/>
 					<c:file name="xml/script.xpl"/>
 				</c:zipfile>

--- a/modules-build-helper/src/it/it-pipeline-module/src/main/java/impl/JavaStep.java
+++ b/modules-build-helper/src/it/it-pipeline-module/src/main/java/impl/JavaStep.java
@@ -1,0 +1,28 @@
+package impl;
+
+import net.sf.saxon.s9api.QName;
+import net.sf.saxon.s9api.SaxonApiException;
+import org.daisy.common.xproc.calabash.XProcStepProvider;
+
+import com.xmlcalabash.core.XProcException;
+import com.xmlcalabash.core.XProcRuntime;
+import com.xmlcalabash.core.XProcStep;
+import com.xmlcalabash.library.Identity;
+import com.xmlcalabash.runtime.XAtomicStep;
+
+public class JavaStep extends Identity {
+	
+	private JavaStep(XProcRuntime runtime, XAtomicStep step) {
+		super(runtime, step);
+	}
+
+	@Override
+	public void run() throws SaxonApiException {
+	}
+	
+	public static class Provider implements XProcStepProvider {
+		public XProcStep newStep(XProcRuntime runtime, XAtomicStep step) {
+			return new JavaStep(runtime, step);
+		}
+	}
+}

--- a/modules-build-helper/src/main/java/org/daisy/pipeline/maven/plugin/DependenciesPackageListMojo.java
+++ b/modules-build-helper/src/main/java/org/daisy/pipeline/maven/plugin/DependenciesPackageListMojo.java
@@ -1,0 +1,83 @@
+package org.daisy.pipeline.maven.plugin;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.jar.JarFile;
+import java.util.jar.JarEntry;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+
+@Mojo(
+	name = "dependencies-package-list",
+	defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
+	requiresDependencyResolution = ResolutionScope.COMPILE
+)
+public class DependenciesPackageListMojo extends AbstractMojo {
+	
+	@Parameter(
+		defaultValue = "${project.build.directory}/dependencies-package-list/"
+	)
+	private File outputDirectory;
+	
+	@Parameter(
+		required = true
+	)
+	private String includes;
+	
+	@Parameter(
+		readonly = true,
+		defaultValue = "${project}"
+	)
+	private MavenProject mavenProject;
+	
+	public void execute() throws MojoFailureException {
+		try {
+			Set<String> packages = new HashSet<String>(); {
+				for (String p : mavenProject.getCompileClasspathElements()) {
+					File f = new File(p);
+					if (f.isDirectory()) {
+						// this is probably the target/classes directory, which is not a dependency
+					} else {
+						JarFile jar = new JarFile(f);
+						for (Enumeration<JarEntry> entries = jar.entries(); entries.hasMoreElements();) {
+							JarEntry e = entries.nextElement();
+							if (!e.isDirectory()) {
+								String name = e.getName();
+								if (name.endsWith(".class")) {
+									int i = name.lastIndexOf('/');
+									if (i > 0)
+										packages.add(name.substring(0, i).replace("/", "."));
+								}
+							}
+						}
+					}
+				}
+			}
+			List<String> sortedPackages = new ArrayList(packages);
+			Collections.sort(sortedPackages);
+			String[] includesArray = includes.replaceAll("\\s", "").split(",(?![^{]*})");
+			outputDirectory.mkdirs();
+			PrintWriter writer = new PrintWriter(new File(outputDirectory, "package-list"), "UTF-8");
+			for (String p : sortedPackages)
+				for (String i : includesArray)
+					if (i.equals(p) || i.endsWith(".*") && p.startsWith(i.substring(0, i.length() - 1)))
+						writer.println(p);
+			writer.close();
+		} catch (Throwable e) {
+			e.printStackTrace();
+			throw new MojoFailureException(e.getMessage(), e);
+		}
+	}
+}


### PR DESCRIPTION
containing a list of all Java packages in the project dependencies. This package-file is needed to make javadoc link up the different modules.